### PR TITLE
Minor: Simplified - Error generation.

### DIFF
--- a/src/io/loader.rs
+++ b/src/io/loader.rs
@@ -47,7 +47,7 @@ impl AssetLoader for Gaussian3dLoader {
 
                 #[cfg(not(feature = "io_ply"))]
                 {
-                    Err(std::io::Error::new(ErrorKind::Other, "ply support not enabled, enable with io_ply feature"))
+                    Err(std::io::Error::other("ply support not enabled, enable with io_ply feature"))
                 }
             },
             Some(ext) if ext == "gcloud" => {
@@ -55,7 +55,7 @@ impl AssetLoader for Gaussian3dLoader {
 
                 Ok(cloud)
             },
-            _ => Err(std::io::Error::new(ErrorKind::Other, "only .ply and .gcloud supported")),
+            _ => Err(std::io::Error::other("only .ply and .gcloud supported")),
         }
     }
 
@@ -95,13 +95,13 @@ impl AssetLoader for Gaussian4dLoader {
 
                 #[cfg(not(feature = "io_ply"))]
                 {
-                    Err(std::io::Error::new(ErrorKind::Other, "ply4d support not enabled, enable with io_ply feature"))
+                    Err(std::io::Error::other("ply4d support not enabled, enable with io_ply feature"))
                 }
             },
             Some(ext) if ext == "gc4d" => {
                 Ok(PlanarGaussian4d::decode(bytes.as_slice()))
             },
-            _ => Err(std::io::Error::new(ErrorKind::Other, "only .ply4d and .gc4d supported")),
+            _ => Err(std::io::Error::other("only .ply4d and .gc4d supported")),
         }
     }
 

--- a/src/io/scene.rs
+++ b/src/io/scene.rs
@@ -176,7 +176,7 @@ impl AssetLoader for GaussianSceneLoader {
 
                 Ok(scene)
             },
-            _ => Err(std::io::Error::new(ErrorKind::Other, "only .json supported")),
+            _ => Err(std::io::Error::other("only .json supported")),
         }
     }
 


### PR DESCRIPTION
All changes are of the form :-

```
- _ => Err(std::io::Error::new(ErrorKind::Other, "only .ply4d and .gc4d supported")),
+ _ => Err(std::io::Error::other("only .ply4d and .gc4d supported")),
```