### PR TITLE
Minor: workflows - Bump actions/checkout to version 4.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup ${{ matrix.rust-toolchain }} rust toolchain with caching
       uses: brndnmtthws/rust-action@v1
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup ${{ matrix.rust-toolchain }} rust toolchain with caching
       uses: brndnmtthws/rust-action@v1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup ${{ matrix.rust-toolchain }} rust toolchain with caching
       uses: brndnmtthws/rust-action@v1

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup nightly rust toolchain with caching
         uses: brndnmtthws/rust-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup ${{ matrix.rust-toolchain }} rust toolchain with caching
       uses: brndnmtthws/rust-action@v1
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup ${{ matrix.rust-toolchain }} rust toolchain with caching
       uses: brndnmtthws/rust-action@v1

--- a/.github/workflows/todo_tracker.yml
+++ b/.github/workflows/todo_tracker.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: "TODO to Issue"
       uses: "alstr/todo-to-issue-action@v4"


### PR DESCRIPTION
As reported in in #183,  there is a difference between local test behaviour and github's respone

My reposonse to fix this is a indirect approach .. that is bring all workflow dependencies upto latest 

In this project  actions/checkout in a major number behind, and in unrelated news we can fix a deprecation issue.

> The actions/checkout@v3 action uses node16 under the hood, which is deprecated by github.
> We should switch to actions/checkout@v4, in the docs and for generating the file.
> 

<https://github.com/denoland/fresh/issues/2285#issue-2104087721>