### PR TITLE
Minor: workflows - Bump actions/cache to version 4.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/bin/


### PR DESCRIPTION
Minor: actions/cache version 3 is deprecated. Long live verison 4