### PR TITLE
fix: resolve incorrect depth mode rendering

### DIFF
--- a/src/render/gaussian.wgsl
+++ b/src/render/gaussian.wgsl
@@ -331,8 +331,8 @@ fn vs_points(
     let first_position = vec4<f32>(get_position(get_entry(1u).value), 1.0);
     let last_position = vec4<f32>(get_position(get_entry(gaussian_uniforms.count - 1u).value), 1.0);
 
-    let min_position = (gaussian_uniforms.transform * first_position).xyz;
-    let max_position = (gaussian_uniforms.transform * last_position).xyz;
+    let min_position = (gaussian_uniforms.transform * last_position).xyz;
+    let max_position = (gaussian_uniforms.transform * first_position).xyz;
 
     let camera_position = view.world_position;
 


### PR DESCRIPTION
## Description
This PR corrects an issue with the depth sorting order for Gaussian point rendering.

## Problem
As I understand the rendering pipeline, once the camera is set, the 3D Gaussian points should be processed as "translucent objects." This requires sorting them from **farthest to nearest** relative to the camera. Consequently, in the sorted array:
- The **first** point should be the **farthest**.
- The **last** point should be the **nearest**.

However, the current implementation in `gaussian.wgsl` appears to have this order reversed, which may lead to incorrect blending and visual artifacts.

## Solution
The depth-related logic in `gaussian.wgsl` has been adjusted to ensure the points are sorted and processed in the correct "farthest first" order.

## Feature Request: Output Linear Depth in a Single-Channel Image

I've noticed the depth map is currently saved as an RGB image. Would it be possible to modify the system to also (or alternatively) output a single-channel depth map?

The goal is to have an image where the value of each pixel (e.g., in the R channel if saved in a format that supports it) directly encodes the linear depth from the camera to the Gaussian point. A grayscale image would be perfectly suited for this.