### PR TITLE
fix(4d): use t2 (not t1) for the second temporal SH band

### DIFF
--- a/src/material/spherindrical_harmonics.wgsl
+++ b/src/material/spherindrical_harmonics.wgsl
@@ -103,7 +103,7 @@ fn spherindrical_harmonics_lookup(
     #if SH_DEGREE_TIME > 1
         let t2 = cos(4.0 * PI * theta);
 
-        color += t1 * (
+        color += t2 * (
             l0m0 * vec3<f32>(sh[ 96], sh[ 97], sh[ 98]) +
             l1m1 * vec3<f32>(sh[ 99], sh[100], sh[101]) +
             l1m0 * vec3<f32>(sh[102], sh[103], sh[104]) +


### PR DESCRIPTION
## What

In `spherindrical_harmonics_lookup` (`src/material/spherindrical_harmonics.wgsl`), the `SH_DEGREE_TIME > 1` block computes the second temporal basis function

```wgsl
let t2 = cos(4.0 * PI * theta);
```

but then scales the second-order temporal coefficients (`sh[96..=143]`) by **`t1`** (`cos(2*PI*theta)`, the first harmonic) instead of `t2`:

```wgsl
        let t2 = cos(4.0 * PI * theta);

        color += t1 * (        // <- should be t2
            l0m0 * vec3<f32>(sh[ 96], sh[ 97], sh[ 98]) +
            ...
```

`t2` is computed and then never used, which is the tell.

## Why it's a bug

Each temporal band *n* must be weighted by its own basis `cos(2*PI*n*theta)`. Using `t1` for the second band collapses the second temporal harmonic onto the first, so 4D (spherindrical) view-**and-time**-dependent colour is wrong whenever `SH_DEGREE_TIME > 1`. The first-band block just above (`SH_DEGREE_TIME > 0`) correctly uses `t1`.

## Fix

One character: `t1` → `t2` on the second band's scale. No other behaviour changes; `SH_DEGREE_TIME <= 1` is unaffected.