### PR TITLE
cleanup(4d): drop unused `rds` in spherindrical_harmonics_lookup

### DIFF
--- a/src/material/spherindrical_harmonics.wgsl
+++ b/src/material/spherindrical_harmonics.wgsl
@@ -13,8 +13,6 @@ fn spherindrical_harmonics_lookup(
     dir_t: f32,
     sh: array<f32, #{SH_4D_COEFF_COUNT}>,
 ) -> vec3<f32> {
-    let rds = ray_direction * ray_direction;
-
     var color = vec3<f32>(0.5);
 
     // TODO: reinterpret sh as vec3<f32>


### PR DESCRIPTION
`spherindrical_harmonics_lookup` (`src/material/spherindrical_harmonics.wgsl`) computes

```wgsl
let rds = ray_direction * ray_direction;
```

but never reads it. The 4D path builds its own `xx`/`yy`/`zz` (and `xy`/`xz`/`yz`) from `x`/`y`/`z` for the degree-2/3 terms, so `rds` is dead. (Only the 3D `spherical_harmonics_lookup` actually uses an `rds`.)

Removes the dead binding — no behaviour change.

.. or I might be missing something here 