### PR TITLE
fix: clear hidden gaussian clouds by using add_transient in queue_gau…

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -434,7 +434,7 @@ fn queue_gaussians<R: PlanarSync>(
                 );
             let distance = rangefinder.distance(&center.translation());
 
-            transparent_phase.add_retained(Transparent3d {
+            transparent_phase.add_transient(Transparent3d {
                 sorting_info: TransparentSortingInfo3d::Sorted {
                     mesh_center: center.translation(),
                     depth_bias: 0.0,


### PR DESCRIPTION
## Problem
Setting a gaussian cloud entity's Visibility doesn't stop it from rendering. The last-visible frame stays on screen until the entity is despawned.

## Cause
queue_gaussians enqueues each visible cloud with SortedRenderPhase::add_retained. Retained phase items persist across frames — prepare_for_new_frame only drains transient_items, never retained ones. When a cloud becomes hidden, extract_gaussians stops refreshing it and queue_gaussians stops re-adding it, but its previously retained Transparent3d draw command is never removed, so it keeps drawing stale GPU state.

## Fix
Use add_transient instead of add_retained. Clouds are re-evaluated every frame from RenderVisibleEntities, so they should be transient: the phase is rebuilt each frame, hidden clouds drop out, and visible clouds are re-added. No behavior change for the always-visible case.

## Testing
With multiple clouds, toggling a cloud's visibility now removes it immediately; toggling all clouds off renders nothing.