### PR TITLE
[codex] bump bevy_gaussian_splatting to 8.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_gaussian_splatting"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "base64 0.22.1",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_gaussian_splatting"
 description = "bevy gaussian splatting render pipeline plugin"
-version = "8.0.0"
+version = "8.0.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["mosure <mitchell@mosure.me>"]


### PR DESCRIPTION
Bumps bevy_gaussian_splatting from 8.0.0 to 8.0.1 for a patch release.

Pre-publish validation run locally:
- cargo fmt --all -- --check
- git diff --check
- cargo test
- cargo test --no-default-features --features="web io_ply tooling"
- RUN_GPU_RENDER_TESTS=1 cargo test --no-default-features --features headless --test visibility_render -- --nocapture
- cargo clippy --all-features --all-targets -- -D warnings
- cargo publish --dry-run --allow-dirty --locked