### PR TITLE
feat: additive/emissive blend mode (CloudSettings::additive, default off)

### DIFF
--- a/src/gaussian/settings.rs
+++ b/src/gaussian/settings.rs
@@ -105,6 +105,12 @@ pub struct CloudSettings {
     pub time_scale: f32,
     pub time_start: f32,
     pub time_stop: f32,
+    /// Additive/emissive blending. `false` (default) keeps premultiplied alpha-over, which is
+    /// byte-identical to previous behaviour. When `true` the cloud composites `One + One`, so
+    /// overlapping premultiplied fragments accumulate light and glow on a dark background instead
+    /// of alpha-saturating into a solid blob. Additive draws have no occlusion (everything shows
+    /// through), so it suits emissive/procedural content; leave it `false` for solid captures.
+    pub additive: bool,
 }
 
 impl Default for CloudSettings {
@@ -127,6 +133,7 @@ impl Default for CloudSettings {
             time_scale: 1.0,
             time_start: 0.0,
             time_stop: 1.0,
+            additive: false,
         }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -421,6 +421,7 @@ fn queue_gaussians<R: PlanarSync>(
                 rasterize_mode: settings.rasterize_mode,
                 sample_count: msaa.samples(),
                 hdr: view.target_format == TextureFormat::Rgba16Float,
+                additive: settings.additive,
             };
 
             let pipeline = pipelines.specialize(&pipeline_cache, &custom_pipeline, key);
@@ -906,6 +907,9 @@ pub struct CloudPipelineKey {
     pub rasterize_mode: RasterizeMode,
     pub sample_count: u32,
     pub hdr: bool,
+    /// See [`CloudSettings::additive`]. Blending is fixed-function pipeline state rather than
+    /// something the shader can select, so the two modes specialize to distinct pipelines.
+    pub additive: bool,
 }
 
 impl<R: PlanarSync> SpecializedRenderPipeline for CloudPipeline<R> {
@@ -943,7 +947,22 @@ impl<R: PlanarSync> SpecializedRenderPipeline for CloudPipeline<R> {
                 entry_point: Some("fs_main".into()),
                 targets: vec![Some(ColorTargetState {
                     format,
-                    blend: Some(BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    blend: Some(if key.additive {
+                        BlendState {
+                            color: BlendComponent {
+                                src_factor: BlendFactor::One,
+                                dst_factor: BlendFactor::One,
+                                operation: BlendOperation::Add,
+                            },
+                            alpha: BlendComponent {
+                                src_factor: BlendFactor::One,
+                                dst_factor: BlendFactor::One,
+                                operation: BlendOperation::Add,
+                            },
+                        }
+                    } else {
+                        BlendState::PREMULTIPLIED_ALPHA_BLENDING
+                    }),
                     write_mask: ColorWrites::ALL,
                 })],
             }),


### PR DESCRIPTION
adds an opt-in `additive` flag to `CloudSettings`. when false (the default) the pipeline keeps `PREMULTIPLIED_ALPHA_BLENDING`, so behaviour is unchanged. when true the cloud composites `One + One`, so overlapping premultiplied fragments accumulate light and glow on a dark background instead of alpha-saturating into a solid blob — useful for emissive/procedural clouds (nebula/neon looks).

blending is fixed-function pipeline state rather than something the shader can select, so `additive` is threaded through `CloudPipelineKey` and the two modes specialize to distinct pipelines. `CloudPipelineKey` derives `Default`, so the compute/interpolate key that builds with `..Default::default()` gets `false`.

additive draws have no occlusion (everything shows through), so it is meant for glow content on a dark background; solid captures should leave it false.